### PR TITLE
Don't exit when we don't support the current desktop

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -28,6 +28,7 @@ extern const gchar *mode;
 #define CINNAMON_MODE ( g_strcmp0 (mode, "cinnamon") == 0 )
 #define MATE_MODE ( g_strcmp0 (mode, "mate") == 0 )
 #define XFCE_MODE ( g_strcmp0 (mode, "xfce") == 0 )
+#define UNKNOWN_MODE ( g_strcmp0 (mode, "unknown") == 0 )
 
 typedef enum {
   XDG_DESKTOP_PORTAL_ERROR_FAILED     = 0,

--- a/src/xdg-desktop-portal-xapp.c
+++ b/src/xdg-desktop-portal-xapp.c
@@ -103,13 +103,19 @@ on_bus_acquired (GDBusConnection *connection,
 {
   GError *error = NULL;
 
-  if ((CINNAMON_MODE || XFCE_MODE) && !screenshot_init (connection, &error))
+  // For fallback we can handle settings, it's pretty universal, the restm, no.
+  if (!settings_init (connection, &error))
     {
       g_warning ("error: %s\n", error->message);
       g_clear_error (&error);
     }
 
-  if (!settings_init (connection, &error))
+  if (UNKNOWN_MODE)
+  {
+    return;
+  }
+
+  if ((CINNAMON_MODE || XFCE_MODE) && !screenshot_init (connection, &error))
     {
       g_warning ("error: %s\n", error->message);
       g_clear_error (&error);
@@ -221,8 +227,8 @@ main (int argc, char *argv[])
           mode = "xfce";
       else
       {
+          mode = "unknown";
           g_printerr ("Current desktop (XDG_CURRENT_DESKTOP) is unsupported: %s\n", xdg_desktop);
-          return 1;
       }
   }
 


### PR DESCRIPTION
We're expected to provide fallback support (or at least finish registering).

Trial fix for #5