### PR TITLE
fix debian build error due to missing depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,11 @@ Maintainer: Linux Mint <root@linuxmint.com>
 Build-Depends:
  debhelper-compat (= 13),
  libglib2.0-dev (>= 2.44),
+ libgtk-3-dev,
  meson (>= 0.53.0),
+ pkg-config,
+ cmake,
+ systemd,
  xdg-desktop-portal-dev (>= 1.7.1),
 Standards-Version: 4.6.0
 Homepage: https://github.com/linuxmint/xdg-desktop-portal-xapp


### PR DESCRIPTION
- Add libgtk-3-dev, pkg-config, cmake and systemd as build dependencies