### PR TITLE
Update org.freedesktop.impl.portal.Settings backend to v2.

### DIFF
--- a/data/org.gnome.SessionManager.xml
+++ b/data/org.gnome.SessionManager.xml
@@ -97,7 +97,7 @@
       </arg>
       <arg type="u" name="flags" direction="in">
         <doc:doc>
-          <doc:summary>Flags that spefify what should be inhibited</doc:summary>
+          <doc:summary>Flags that specify what should be inhibited</doc:summary>
         </doc:doc>
       </arg>
       <arg type="u" name="inhibit_cookie" direction="out">
@@ -107,7 +107,7 @@
       </arg>
       <doc:doc>
         <doc:summary>
-          Proactively indicates that the calling application is performing an action that should not be interrupted and sets a reason to be displayed to the user when an interruption is about to take placea.
+          Proactively indicates that the calling application is performing an action that should not be interrupted and sets a reason to be displayed to the user when an interruption is about to take place.
         </doc:summary>
         <doc:description>
           <doc:para>Applications should invoke this method when they begin an operation that
@@ -175,7 +175,7 @@
     <method name="IsInhibited">
       <arg type="u" name="flags" direction="in">
         <doc:doc>
-          <doc:summary>Flags that spefify what should be inhibited</doc:summary>
+          <doc:summary>Flags that specify what should be inhibited</doc:summary>
         </doc:doc>
       </arg>
       <arg type="b" name="is_inhibited" direction="out">
@@ -296,7 +296,7 @@
               </doc:item>
               <doc:item>
                 <doc:term>1</doc:term>
-                <doc:definition>No confirmation inferface should be shown.</doc:definition>
+                <doc:definition>No confirmation interface should be shown.</doc:definition>
               </doc:item>
               <doc:item>
                 <doc:term>2</doc:term>

--- a/debian/control
+++ b/debian/control
@@ -5,6 +5,7 @@ Maintainer: Linux Mint <root@linuxmint.com>
 Build-Depends:
  debhelper-compat (= 13),
  libglib2.0-dev (>= 2.44),
+ libgtk-3-dev (>= 3.0),
  meson (>= 0.53.0),
  systemd (>= 242),
  xdg-desktop-portal-dev (>= 1.7.1),

--- a/debian/rules
+++ b/debian/rules
@@ -5,6 +5,11 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 %:
 	dh $@
 
+
+override_dh_auto_configure:
+	dh_auto_configure -- \
+		--buildtype=debug
+
 override_dh_auto_install:
 	dh_auto_install --destdir=debian/tmp
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -57,6 +57,8 @@ deps = [
   meson.get_compiler('c').find_library('m'),
   dependency('glib-2.0', version: '>= 2.44'),
   dependency('gio-unix-2.0'),
+  dependency('gtk+-3.0'),
+  dependency('gdk-3.0'),
   xdg_desktop_portal_dep,
 ]
 

--- a/src/xdg-desktop-portal-xapp.c
+++ b/src/xdg-desktop-portal-xapp.c
@@ -35,6 +35,7 @@
 #include <gio/gio.h>
 #include <gio/gdesktopappinfo.h>
 #include <gio/gunixfdlist.h>
+#include <gtk/gtk.h>
 
 #include <glib/gi18n.h>
 #include <locale.h>
@@ -49,7 +50,6 @@
 #include "settings.h"
 #include "wallpaper.h"
 
-static GMainLoop *loop = NULL;
 static GHashTable *outstanding_handles = NULL;
 
 static gboolean opt_verbose;
@@ -153,7 +153,7 @@ on_name_lost (GDBusConnection *connection,
               gpointer         user_data)
 {
   g_debug ("name lost");
-  g_main_loop_quit (loop);
+  gtk_main_quit ();
 }
 
 int
@@ -237,7 +237,7 @@ main (int argc, char *argv[])
 
   g_set_prgname ("xdg-desktop-portal-xapp");
 
-  loop = g_main_loop_new (NULL, FALSE);
+  gtk_init (NULL, NULL);
 
   outstanding_handles = g_hash_table_new (g_str_hash, g_str_equal);
 
@@ -257,8 +257,7 @@ main (int argc, char *argv[])
                              NULL,
                              NULL);
 
-  g_main_loop_run (loop);
-
+  gtk_main ();
   g_bus_unown_name (owner_id);
 
   return 0;


### PR DESCRIPTION
- Added high-contrast setting.
- Added accent-color support.
- Refactored to make it easier to add new settings in the future.

Accent color currently attempts to get an accent color by:
- Matching the name with a static list (currently only Mint themes)
- Failing that, it checks a gsettings key.

requires:
linuxmint/xapp@a7d8a1c