### PR TITLE
Implement org.freedesktop.impl.portal.Background.

### DIFF
--- a/data/org.cinnamon.PortalHandlers.xml
+++ b/data/org.cinnamon.PortalHandlers.xml
@@ -1,0 +1,11 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+                      "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<!-- GDBus 2.48.1 -->
+<node>
+  <interface name="org.cinnamon.PortalHandlers">
+    <method name="GetAppStates"> \
+        <arg type="a{sv}" direction="out" name="apps" /> \
+    </method> \
+    <signal name="RunningAppsChanged"/> \
+  </interface>
+</node>

--- a/data/xapp.portal
+++ b/data/xapp.portal
@@ -1,4 +1,4 @@
 [portal]
 DBusName=org.freedesktop.impl.portal.desktop.xapp
-Interfaces=org.freedesktop.impl.portal.Wallpaper;org.freedesktop.impl.portal.Inhibit;org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.Lockdown;org.freedesktop.impl.portal.Settings;
+Interfaces=org.freedesktop.impl.portal.Wallpaper;org.freedesktop.impl.portal.Inhibit;org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.Lockdown;org.freedesktop.impl.portal.Settings;org.freedesktop.impl.portal.Background;
 UseIn=X-Cinnamon;MATE;XFCE;

--- a/src/background.c
+++ b/src/background.c
@@ -1,0 +1,259 @@
+#define _GNU_SOURCE 1
+
+#include <config.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include <glib/gstdio.h>
+#include <gio/gdesktopappinfo.h>
+
+#include "common-dbus.h"
+
+#include "utils.h"
+
+static OrgCinnamonPortalHandlers *portal_handlers;
+static GVariant *app_state;
+
+static gboolean
+needs_quoting (const char *arg)
+{
+    while (*arg != 0)
+      {
+        char c = *arg;
+        if (!g_ascii_isalnum (c) &&
+            !(c == '-' || c == '/' || c == '~' ||
+              c == ':' || c == '.' || c == '_' ||
+              c == '=' || c == '@'))
+          return TRUE;
+        arg++;
+      }
+    return FALSE;
+}
+
+char *
+flatpak_quote_argv (const char *argv[],
+                    gssize      len)
+{
+    GString *res = g_string_new ("");
+    int i;
+
+    if (len == -1)
+      len = g_strv_length ((char **) argv);
+
+    for (i = 0; i < len; i++)
+      {
+        if (i != 0)
+          g_string_append_c (res, ' ');
+  
+        if (needs_quoting (argv[i]))
+          {
+            g_autofree char *quoted = g_shell_quote (argv[i]);
+            g_string_append (res, quoted);
+          }
+        else
+          g_string_append (res, argv[i]);
+      }
+
+    return g_string_free (res, FALSE);
+}
+
+typedef enum {
+    AUTOSTART_FLAGS_NONE        = 0,
+    AUTOSTART_FLAGS_ACTIVATABLE = 1 << 0,
+} AutostartFlags;
+
+static gboolean
+handle_enable_autostart (XdpImplBackground      *object,
+                         GDBusMethodInvocation  *invocation,
+                         const char             *app_id,
+                         gboolean                enable,
+                         const char * const     *commandline,
+                         guint                   flags)
+{
+    g_autofree gchar *dir = NULL;
+    g_autofree gchar *path = NULL;
+    gchar *file = NULL;
+    gboolean result = FALSE;
+
+    g_debug ("background: handle EnableAutostart");
+
+    file = g_strconcat (app_id, ".desktop", NULL);
+    dir = g_build_filename (g_get_user_config_dir (), "autostart", NULL);
+    path = g_build_filename (dir, file, NULL);
+    g_free (file);
+
+
+    if (enable)
+    {
+        GKeyFile *keyfile = NULL;
+        GError *error = NULL;
+        g_autofree gchar *exec = NULL;
+
+        if (g_mkdir_with_parents (dir, 0755) != 0)
+        {
+            g_warning ("Failed to create dirs %s", dir);
+            xdp_impl_background_complete_enable_autostart (object, invocation, FALSE);
+            return TRUE;
+        }
+
+        exec = flatpak_quote_argv ((const char **) commandline, -1);
+
+        keyfile = g_key_file_new ();
+
+        g_key_file_set_string (keyfile,
+                               G_KEY_FILE_DESKTOP_GROUP,
+                               G_KEY_FILE_DESKTOP_KEY_TYPE,
+                               "Application");
+        g_key_file_set_string (keyfile,
+                               G_KEY_FILE_DESKTOP_GROUP,
+                               G_KEY_FILE_DESKTOP_KEY_NAME,
+                               app_id);
+        g_key_file_set_string (keyfile,
+                               G_KEY_FILE_DESKTOP_GROUP,
+                               G_KEY_FILE_DESKTOP_KEY_EXEC,
+                               exec);
+        if (flags & AUTOSTART_FLAGS_ACTIVATABLE)
+        {
+            g_key_file_set_boolean (keyfile,
+                                    G_KEY_FILE_DESKTOP_GROUP,
+                                    G_KEY_FILE_DESKTOP_KEY_DBUS_ACTIVATABLE,
+                                    TRUE);
+        }
+
+        g_key_file_set_string (keyfile,
+                               G_KEY_FILE_DESKTOP_GROUP,
+                               "X-Flatpak",
+                               app_id);
+
+        if (!g_key_file_save_to_file (keyfile, path, &error))
+        {
+          g_warning ("Failed to save %s: %s", path, error->message);
+          g_clear_error (&error);
+        }
+        else
+        {
+            g_debug ("Wrote autostart file %s", path);
+            result = TRUE;
+        }
+
+        g_key_file_unref (keyfile);
+    }
+    else
+    {
+        g_unlink (path);
+        g_debug ("Removed %s", path);
+    }
+
+    xdp_impl_background_complete_enable_autostart (object, invocation, result);
+    return TRUE;
+}
+
+static GVariant *
+get_app_state (void)
+{
+    g_autoptr(GVariant) apps = NULL;
+
+    if (!org_cinnamon_portal_handlers_call_get_app_states_sync (portal_handlers, &apps, NULL, NULL))
+      {
+        return NULL;
+      }
+
+    if (apps)
+      {
+          return g_variant_ref (apps);
+      }
+
+    return NULL;
+}
+
+static gboolean
+handle_get_app_state (XdpImplBackground *object,
+                      GDBusMethodInvocation *invocation)
+{
+    g_debug ("background: handle GetAppState");
+
+    if (app_state == NULL)
+        app_state = get_app_state ();
+
+    if (app_state == NULL)
+    {
+        g_dbus_method_invocation_return_error (invocation,
+                                               XDG_DESKTOP_PORTAL_ERROR,
+                                               XDG_DESKTOP_PORTAL_ERROR_FAILED,
+                                               "Could not get window list");
+    }
+    else
+    {
+        xdp_impl_background_complete_get_app_state (object, invocation, app_state);
+    }
+
+    return TRUE;
+}
+
+#define NOTIFY_BACKGROUND_ALLOW 1
+
+static gboolean
+handle_notify_background (XdpImplBackground     *object,
+                          GDBusMethodInvocation *invocation,
+                          const char            *handle,
+                          const char            *app_id,
+                          const char            *name) 
+{
+    GVariantBuilder builder;
+
+    g_variant_builder_init (&builder, G_VARIANT_TYPE_VARDICT);
+    g_variant_builder_add (&builder, "{sv}", "result", g_variant_new_uint32 (NOTIFY_BACKGROUND_ALLOW));
+    xdp_impl_background_complete_notify_background (object, invocation, 0, g_variant_builder_end (&builder));
+    return TRUE;
+}
+
+static void
+on_cinnamon_signal (OrgCinnamonPortalHandlers *proxy,
+                    const gchar               *sender_name,
+                    const gchar               *signal_name,
+                    GVariant                  *parameters,
+                    gpointer                   user_data)
+{
+    if (g_strcmp0 (signal_name, "RunningAppsChanged") == 0)
+    {
+        g_debug ("RunningAppsChanged signal received from Cinnamon");
+        g_clear_pointer (&app_state, g_variant_unref);
+        xdp_impl_background_emit_running_applications_changed (XDP_IMPL_BACKGROUND (user_data));
+    }
+}
+
+gboolean
+background_init (GDBusConnection *bus,
+                 GError **error)
+{
+    GDBusInterfaceSkeleton *helper;
+
+    helper = G_DBUS_INTERFACE_SKELETON (xdp_impl_background_skeleton_new ());
+
+    g_signal_connect (helper, "handle-enable-autostart", G_CALLBACK (handle_enable_autostart), NULL);
+    g_signal_connect (helper, "handle-get-app-state", G_CALLBACK (handle_get_app_state), NULL);
+    g_signal_connect (helper, "handle-notify-background", G_CALLBACK (handle_notify_background), NULL);
+
+    if (!g_dbus_interface_skeleton_export (helper,
+                                           bus,
+                                           DESKTOP_PORTAL_OBJECT_PATH,
+                                           error))
+        return FALSE;
+
+    portal_handlers = org_cinnamon_portal_handlers_proxy_new_sync (bus,
+                                                                   G_DBUS_PROXY_FLAGS_DO_NOT_AUTO_START,
+                                                                   "org.Cinnamon",
+                                                                   "/org/Cinnamon",
+                                                                   NULL,
+                                                                   error);
+    g_signal_connect (portal_handlers, "g-signal", G_CALLBACK (on_cinnamon_signal), helper);
+
+    if (portal_handlers == NULL)
+        return FALSE;
+
+    g_debug ("providing %s", g_dbus_interface_skeleton_get_info (helper)->name);
+
+    return TRUE;
+}

--- a/src/background.h
+++ b/src/background.h
@@ -1,0 +1,20 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+
+gboolean background_init (GDBusConnection *bus, GError **error);

--- a/src/meson.build
+++ b/src/meson.build
@@ -11,6 +11,7 @@ desktop_portal_interfaces_dir = xdg_desktop_portal_dep.get_variable(
 )
 
 desktop_portal_dbus_interfaces = [
+  desktop_portal_interfaces_dir / 'org.freedesktop.impl.portal.Background.xml',
   desktop_portal_interfaces_dir / 'org.freedesktop.impl.portal.Inhibit.xml',
   desktop_portal_interfaces_dir / 'org.freedesktop.impl.portal.Lockdown.xml',
   desktop_portal_interfaces_dir / 'org.freedesktop.impl.portal.Request.xml',
@@ -35,6 +36,7 @@ desktop_dbus_interfaces = files(
   top_srcdir / 'data' / 'org.freedesktop.ScreenSaver.xml',
   top_srcdir / 'data' / 'org.gnome.SessionManager.xml',
   top_srcdir / 'data' / 'org.gnome.Shell.Screenshot.xml',
+  top_srcdir / 'data' / 'org.cinnamon.PortalHandlers.xml',
   top_srcdir / 'data' / 'org.cinnamon.ScreenSaver.xml',
   top_srcdir / 'data' / 'org.gnome.ScreenSaver.xml',
   top_srcdir / 'data' / 'org.mate.ScreenSaver.xml'
@@ -63,6 +65,7 @@ deps = [
 ]
 
 sources = built_sources + files(
+  'background.c',
   'inhibit.c',
   'lockdown.c',
   'request.c',

--- a/src/xdg-desktop-portal-xapp.c
+++ b/src/xdg-desktop-portal-xapp.c
@@ -43,6 +43,7 @@
 #include "xdg-desktop-portal-dbus.h"
 
 #include "utils.h"
+#include "background.h"
 #include "inhibit.h"
 #include "lockdown.h"
 #include "request.h"
@@ -133,6 +134,12 @@ on_bus_acquired (GDBusConnection *connection,
     }
 
   if (!wallpaper_init (connection, &error))
+    {
+      g_warning ("error: %s\n", error->message);
+      g_clear_error (&error);
+    }
+
+  if (CINNAMON_MODE && !background_init (connection, &error))
     {
       g_warning ("error: %s\n", error->message);
       g_clear_error (&error);


### PR DESCRIPTION
Closes: #2

- GetAppState: it currently can't retrieve info on apps with no
  window - this applies to apps that minimize to the system tray
  while they're not visible. This is a limitation in Cinnamon.

- RunningApplicationsChanged: works to the extent the windowless
  application issue allows.

- NotifyBackground - Currently, always allows background apps,
  which makes it consistent with normal system apps.

- EnableAutostart: Fully functional.

I note that while NotifyBackground creates a desktop file
successfully, disabling 'autostart' in a couple of test apps
does not delete that file (testing this with -xapp portal works
fine - the main portal backend isn't receiving anything at all
from the app (the backgrounding remains allowed in the permission
store also) - this could be deliberate.