### PR TITLE
Implement AppChooser portal

### DIFF
--- a/data/xapp.portal
+++ b/data/xapp.portal
@@ -1,4 +1,4 @@
 [portal]
 DBusName=org.freedesktop.impl.portal.desktop.xapp
-Interfaces=org.freedesktop.impl.portal.Wallpaper;org.freedesktop.impl.portal.Inhibit;org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.Lockdown;org.freedesktop.impl.portal.Settings;org.freedesktop.impl.portal.Background;
+Interfaces=org.freedesktop.impl.portal.AppChooser;org.freedesktop.impl.portal.Wallpaper;org.freedesktop.impl.portal.Inhibit;org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.Lockdown;org.freedesktop.impl.portal.Settings;org.freedesktop.impl.portal.Background;
 UseIn=X-Cinnamon;MATE;XFCE;

--- a/src/appchooser.c
+++ b/src/appchooser.c
@@ -1,0 +1,282 @@
+/*
+ * Copyright © 2016 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Matthias Clasen <mclasen@redhat.com>
+ */
+
+#define _GNU_SOURCE 1
+
+#include "config.h"
+
+#include "appchooser.h"
+#include "request.h"
+#include "utils.h"
+
+#include <string.h>
+
+#include <gtk/gtk.h>
+
+#include <gio/gio.h>
+#include <gio/gdesktopappinfo.h>
+#include <gio/gunixfdlist.h>
+
+#include <glib/gi18n.h>
+
+#include "xdg-desktop-portal-dbus.h"
+
+#include "appchooserdialog.h"
+#include "externalwindow.h"
+
+static GHashTable *handles;
+
+typedef struct {
+  XdpImplAppChooser *impl;
+  GDBusMethodInvocation *invocation;
+  Request *request;
+  GtkWidget *dialog;
+  ExternalWindow *external_parent;
+
+  char *chosen;
+  int response;
+
+} AppDialogHandle;
+
+static void
+app_dialog_handle_free (gpointer data)
+{
+  AppDialogHandle *handle = data;
+
+  g_hash_table_remove (handles, handle->request->id);
+  g_clear_object (&handle->external_parent);
+  g_object_unref (handle->request);
+  g_object_unref (handle->dialog);
+  g_free (handle->chosen);
+
+  g_free (handle);
+}
+
+static void
+app_dialog_handle_close (AppDialogHandle *handle)
+{
+  gtk_widget_destroy (handle->dialog);
+  app_dialog_handle_free (handle);
+}
+
+static void
+send_response (AppDialogHandle *handle)
+{
+  GVariantBuilder opt_builder;
+
+  g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
+  g_variant_builder_add (&opt_builder, "{sv}", "choice", g_variant_new_string (handle->chosen ? handle->chosen : ""));
+
+  if (handle->request->exported)
+    request_unexport (handle->request);
+
+  xdp_impl_app_chooser_complete_choose_application (handle->impl,
+                                                    handle->invocation,
+                                                    handle->response,
+                                                    g_variant_builder_end (&opt_builder));
+
+  app_dialog_handle_close (handle);
+}
+
+static void
+handle_app_chooser_close (AppChooserDialog *dialog,
+                          gpointer data)
+{
+  AppDialogHandle *handle = data;
+  GAppInfo *info;
+
+  info = app_chooser_dialog_get_info (dialog);
+  if (info != NULL)
+    {
+      const char *desktop_id = g_app_info_get_id (info);
+      handle->response = 0;
+      handle->chosen = g_strndup (desktop_id, strlen (desktop_id) - strlen (".desktop"));
+    }
+  else
+    {
+      handle->response = 1;
+      handle->chosen = NULL;
+    }
+
+  send_response (handle);
+}
+
+static gboolean
+handle_close (XdpImplRequest *object,
+              GDBusMethodInvocation *invocation,
+              AppDialogHandle *handle)
+{
+  GVariantBuilder opt_builder;
+
+  g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
+  xdp_impl_app_chooser_complete_choose_application (handle->impl,
+                                                    handle->invocation,
+                                                    2,
+                                                    g_variant_builder_end (&opt_builder));
+  app_dialog_handle_close (handle);
+
+  if (handle->request->exported)
+    request_unexport (handle->request);
+
+  xdp_impl_request_complete_close (object, invocation);
+
+  return TRUE;
+}
+
+static gboolean
+handle_choose_application (XdpImplAppChooser *object,
+                           GDBusMethodInvocation *invocation,
+                           const char *arg_handle,
+                           const char *arg_app_id,
+                           const char *arg_parent_window,
+                           const char **choices,
+                           GVariant *arg_options)
+{
+  g_autoptr(Request) request = NULL;
+  GtkWidget *dialog;
+  AppDialogHandle *handle;
+  const char *sender;
+  const char *latest_chosen_id;
+  const char *content_type;
+  const char *location;
+  gboolean modal;
+  GdkDisplay *display;
+  GdkScreen *screen;
+  ExternalWindow *external_parent = NULL;
+  GtkWidget *fake_parent;
+
+  sender = g_dbus_method_invocation_get_sender (invocation);
+
+  request = request_new (sender, arg_app_id, arg_handle);
+
+  if (!g_variant_lookup (arg_options, "last_choice", "&s", &latest_chosen_id))
+    latest_chosen_id = NULL;
+  if (!g_variant_lookup (arg_options, "modal", "b", &modal))
+    modal = TRUE;
+  if (!g_variant_lookup (arg_options, "content_type", "&s", &content_type))
+    content_type = NULL;
+  if (!g_variant_lookup (arg_options, "filename", "&s", &location) &&
+      !g_variant_lookup (arg_options, "uri", "&s", &location))
+    location = NULL;
+
+  if (arg_parent_window)
+    {
+      external_parent = create_external_window_from_handle (arg_parent_window);
+      if (!external_parent)
+        g_warning ("Failed to associate portal window with parent window %s",
+                   arg_parent_window);
+    }
+
+  if (external_parent)
+    display = external_window_get_display (external_parent);
+  else
+    display = gdk_display_get_default ();
+  screen = gdk_display_get_default_screen (display);
+
+  fake_parent = g_object_new (GTK_TYPE_WINDOW,
+                              "type", GTK_WINDOW_TOPLEVEL,
+                              "screen", screen,
+                              NULL);
+  g_object_ref_sink (fake_parent);
+
+  dialog = GTK_WIDGET (app_chooser_dialog_new (choices, latest_chosen_id, content_type, location));
+  gtk_window_set_transient_for (GTK_WINDOW (dialog), GTK_WINDOW (fake_parent));
+
+  gtk_window_set_modal (GTK_WINDOW (dialog), modal);
+
+  handle = g_new0 (AppDialogHandle, 1);
+  handle->impl = object;
+  handle->invocation = invocation;
+  handle->request = g_object_ref (request);
+  handle->dialog = g_object_ref (dialog);
+  handle->external_parent = external_parent;
+
+  g_hash_table_insert (handles, handle->request->id, handle);
+
+  g_signal_connect (request, "handle-close",
+                    G_CALLBACK (handle_close), handle);
+
+  g_signal_connect (dialog, "close",
+                    G_CALLBACK (handle_app_chooser_close), handle);
+
+  gtk_widget_realize (dialog);
+
+  if (external_parent)
+    external_window_set_parent_of (external_parent, gtk_widget_get_window (dialog));
+
+  gtk_window_present (GTK_WINDOW (dialog));
+
+  request_export (request, g_dbus_method_invocation_get_connection (invocation));
+
+  return TRUE;
+}
+
+static gboolean
+handle_update_choices (XdpImplAppChooser *object,
+                       GDBusMethodInvocation *invocation,
+                       const char *arg_handle,
+                       const char **choices)
+{
+  AppDialogHandle *handle;
+  g_autofree char *a = NULL;
+
+  handle = g_hash_table_lookup (handles, arg_handle);
+
+  if (handle == NULL)
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             XDG_DESKTOP_PORTAL_ERROR,
+                                             XDG_DESKTOP_PORTAL_ERROR_NOT_FOUND,
+                                             "Request not found");
+      return TRUE;
+    }
+
+  g_debug ("Updating choices: %s\n", a = g_strjoinv (", ", (char **)choices));
+
+  app_chooser_dialog_update_choices (APP_CHOOSER_DIALOG (handle->dialog), choices);
+
+  g_dbus_method_invocation_return_value (invocation, NULL);
+
+  return TRUE;
+}
+
+gboolean
+app_chooser_init (GDBusConnection *bus,
+                  GError **error)
+{
+  GDBusInterfaceSkeleton *helper;
+
+  helper = G_DBUS_INTERFACE_SKELETON (xdp_impl_app_chooser_skeleton_new ());
+
+  g_signal_connect (helper, "handle-choose-application", G_CALLBACK (handle_choose_application), NULL);
+  g_signal_connect (helper, "handle-update-choices", G_CALLBACK (handle_update_choices), NULL);
+
+  if (!g_dbus_interface_skeleton_export (helper,
+                                         bus,
+                                         DESKTOP_PORTAL_OBJECT_PATH,
+                                         error))
+    return FALSE;
+
+  handles = g_hash_table_new (g_str_hash, g_str_equal);
+
+  g_debug ("providing %s", g_dbus_interface_skeleton_get_info (helper)->name);
+
+  return TRUE;
+}

--- a/src/appchooser.c
+++ b/src/appchooser.c
@@ -125,16 +125,16 @@ handle_close (XdpImplRequest *object,
 {
   GVariantBuilder opt_builder;
 
+  if (handle->request->exported)
+    request_unexport (handle->request);
+
   g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
   xdp_impl_app_chooser_complete_choose_application (handle->impl,
                                                     handle->invocation,
                                                     2,
                                                     g_variant_builder_end (&opt_builder));
+
   app_dialog_handle_close (handle);
-
-  if (handle->request->exported)
-    request_unexport (handle->request);
-
   xdp_impl_request_complete_close (object, invocation);
 
   return TRUE;

--- a/src/appchooser.c
+++ b/src/appchooser.c
@@ -107,7 +107,17 @@ handle_app_chooser_close (AppChooserDialog *dialog,
     {
       const char *desktop_id = g_app_info_get_id (info);
       handle->response = 0;
-      handle->chosen = g_strndup (desktop_id, strlen (desktop_id) - strlen (".desktop"));
+      if (desktop_id != NULL)
+        {
+          if (g_str_has_suffix (desktop_id, ".desktop"))
+            handle->chosen = g_strndup (desktop_id, strlen (desktop_id) - strlen (".desktop"));
+          else
+            handle->chosen = g_strdup (desktop_id);
+        }
+      else
+        {
+          handle->chosen = NULL;
+        }
     }
   else
     {

--- a/src/appchooser.h
+++ b/src/appchooser.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2016 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Matthias Clasen <mclasen@redhat.com>
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+
+gboolean app_chooser_init (GDBusConnection *bus, GError **error);

--- a/src/appchooserdialog.c
+++ b/src/appchooserdialog.c
@@ -1,0 +1,498 @@
+/*
+ * Copyright © 2016 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Matthias Clasen <mclasen@redhat.com>
+ */
+
+#define _GNU_SOURCE 1
+
+#include "config.h"
+
+#include <string.h>
+
+#include <gio/gio.h>
+#include <glib/gi18n.h>
+#include <gio/gdesktopappinfo.h>
+
+#include "appchooserdialog.h"
+#include "appchooserrow.h"
+
+#define LOCATION_MAX_LENGTH 40
+#define INITIAL_LIST_SIZE 3
+
+struct _AppChooserDialog {
+  GtkWindow parent;
+
+  GtkWidget *scrolled_window;
+  GtkWidget *titlebar;
+  GtkWidget *cancel_button;
+  GtkWidget *open_button;
+  GtkWidget *find_software_button;
+  GtkWidget *list;
+  GtkWidget *heading;
+  GtkWidget *stack;
+  GtkWidget *empty_box;
+  GtkWidget *empty_label;
+
+  char *content_type;
+
+  char **choices;
+
+  GtkWidget *selected_row;
+  GtkWidget *more_row;
+
+  GAppInfo *info;
+};
+
+struct _AppChooserDialogClass {
+  GtkWindowClass parent_class;
+
+  void (* close) (AppChooserDialog *dialog);
+};
+
+enum {
+  CLOSE,
+  LAST_SIGNAL
+};
+
+static guint signals[LAST_SIGNAL];
+
+G_DEFINE_TYPE (AppChooserDialog, app_chooser_dialog, GTK_TYPE_WINDOW)
+
+static void
+update_header (GtkListBoxRow *row,
+               GtkListBoxRow *before,
+               gpointer       data)
+{
+  if (before != NULL &&
+      gtk_list_box_row_get_header (row) == NULL)
+    {
+      GtkWidget *separator;
+
+      separator = gtk_separator_new (GTK_ORIENTATION_HORIZONTAL);
+      gtk_widget_show (separator);
+      gtk_list_box_row_set_header (row, separator);
+    }
+}
+
+static void
+app_chooser_dialog_init (AppChooserDialog *dialog)
+{
+  gtk_widget_init_template (GTK_WIDGET (dialog));
+
+  gtk_list_box_set_header_func (GTK_LIST_BOX (dialog->list), update_header, NULL, NULL);
+}
+
+static void
+app_chooser_dialog_finalize (GObject *object)
+{
+  AppChooserDialog *dialog = APP_CHOOSER_DIALOG (object);
+
+  g_free (dialog->content_type);
+  g_strfreev (dialog->choices);
+
+  G_OBJECT_CLASS (app_chooser_dialog_parent_class)->finalize (object);
+}
+
+GAppInfo *
+app_chooser_dialog_get_info (AppChooserDialog *dialog)
+{
+  return dialog->info;
+}
+
+static void
+close_dialog (AppChooserDialog *dialog,
+              GAppInfo *info)
+{
+  dialog->info = info;
+  g_signal_emit (dialog, signals[CLOSE], 0);
+}
+
+static void
+show_more (AppChooserDialog *dialog)
+{
+  int i;
+
+  gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (dialog->scrolled_window),
+                                  GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
+  gtk_window_set_resizable (GTK_WINDOW (dialog), TRUE);
+  gtk_widget_hide (dialog->more_row);
+
+  g_return_if_fail (g_strv_length ((char **)dialog->choices) > INITIAL_LIST_SIZE);
+
+  for (i = INITIAL_LIST_SIZE; dialog->choices[i]; i++)
+    {
+      g_autofree char *desktop_id = g_strconcat (dialog->choices[i], ".desktop", NULL);
+      g_autoptr(GAppInfo) info = G_APP_INFO (g_desktop_app_info_new (desktop_id));
+      GtkWidget *row;
+
+      row = GTK_WIDGET (app_chooser_row_new (info));
+      gtk_widget_set_visible (row, TRUE);
+      gtk_list_box_insert (GTK_LIST_BOX (dialog->list), row, -1);
+   }
+}
+
+static void
+row_activated (GtkListBox *list,
+               GtkWidget *row,
+               AppChooserDialog *dialog)
+{
+  GAppInfo *info = NULL;
+
+  if (row == dialog->more_row)
+    {
+      show_more (dialog);
+      return;
+    }
+
+  if (dialog->selected_row)
+    info = app_chooser_row_get_info (APP_CHOOSER_ROW (dialog->selected_row));
+  close_dialog (dialog, info);
+}
+
+static void
+row_selected (GtkListBox *list,
+              GtkWidget *row,
+              AppChooserDialog *dialog)
+{
+  gtk_widget_set_sensitive (dialog->open_button, TRUE);
+  dialog->selected_row = row;
+}
+
+static void
+cancel_clicked (GtkWidget *button,
+                AppChooserDialog *dialog)
+{
+  close_dialog (dialog, NULL);
+}
+
+static void
+open_clicked (GtkWidget *button,
+              AppChooserDialog *dialog)
+{
+  GAppInfo *info = NULL;
+
+  if (dialog->selected_row)
+    info = app_chooser_row_get_info (APP_CHOOSER_ROW (dialog->selected_row));
+  close_dialog (dialog, info);
+}
+
+static void
+show_error_dialog (const gchar *primary,
+                   const gchar *secondary,
+                   GtkWindow *parent)
+{
+  GtkWidget *message_dialog;
+
+  message_dialog = gtk_message_dialog_new (parent, 0,
+                                           GTK_MESSAGE_ERROR,
+                                           GTK_BUTTONS_OK,
+                                           NULL);
+  g_object_set (message_dialog,
+                "text", primary,
+                "secondary-text", secondary,
+                NULL);
+  gtk_dialog_set_default_response (GTK_DIALOG (message_dialog), GTK_RESPONSE_OK);
+  gtk_widget_show (message_dialog);
+  g_signal_connect (message_dialog, "response",
+                    G_CALLBACK (gtk_widget_destroy), NULL);
+}
+
+static void
+launch_software (AppChooserDialog *dialog)
+{
+  g_autoptr(GSubprocess) process = NULL;
+  g_autoptr(GError) error = NULL;
+
+  process = g_subprocess_new (0, &error, "mintinstall", NULL, NULL);
+  if (!process)
+    show_error_dialog (_("Failed to start Software Manager"), error->message, GTK_WINDOW (dialog));
+}
+
+static void
+find_in_software (GtkWidget *button,
+                  AppChooserDialog *dialog)
+{
+  launch_software (dialog);
+}
+
+static gboolean
+app_chooser_delete_event (GtkWidget *dialog, GdkEventAny *event)
+{
+  close_dialog (APP_CHOOSER_DIALOG (dialog), NULL);
+
+  return TRUE;
+}
+
+static void
+app_chooser_dialog_close (AppChooserDialog *dialog)
+{
+  gtk_window_close (GTK_WINDOW (dialog));
+}
+
+static void
+app_chooser_dialog_class_init (AppChooserDialogClass *class)
+{
+  GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (class);
+  GObjectClass *object_class = G_OBJECT_CLASS (class);
+  GtkBindingSet *binding_set;
+
+  object_class->finalize = app_chooser_dialog_finalize;
+
+  widget_class->delete_event = app_chooser_delete_event;
+
+  class->close = app_chooser_dialog_close;
+
+  signals[CLOSE] = g_signal_new ("close",
+                                G_TYPE_FROM_CLASS (class),
+                                G_SIGNAL_ACTION | G_SIGNAL_RUN_LAST,
+                                0,
+                                NULL, NULL,
+                                NULL,
+                                G_TYPE_NONE, 0);
+
+  binding_set = gtk_binding_set_by_class (class);
+  gtk_binding_entry_add_signal (binding_set, GDK_KEY_Escape, 0, "close", 0);
+
+  gtk_widget_class_set_template_from_resource (widget_class, "/org/freedesktop/portal/desktop/xapp/appchooserdialog.ui");
+  gtk_widget_class_bind_template_child (widget_class, AppChooserDialog, scrolled_window);
+  gtk_widget_class_bind_template_child (widget_class, AppChooserDialog, titlebar);
+  gtk_widget_class_bind_template_child (widget_class, AppChooserDialog, cancel_button);
+  gtk_widget_class_bind_template_child (widget_class, AppChooserDialog, open_button);
+  gtk_widget_class_bind_template_child (widget_class, AppChooserDialog, find_software_button);
+  gtk_widget_class_bind_template_child (widget_class, AppChooserDialog, list);
+  gtk_widget_class_bind_template_child (widget_class, AppChooserDialog, heading);
+  gtk_widget_class_bind_template_child (widget_class, AppChooserDialog, stack);
+  gtk_widget_class_bind_template_child (widget_class, AppChooserDialog, empty_box);
+  gtk_widget_class_bind_template_child (widget_class, AppChooserDialog, empty_label);
+
+  gtk_widget_class_bind_template_callback (widget_class, row_activated);
+  gtk_widget_class_bind_template_callback (widget_class, row_selected);
+  gtk_widget_class_bind_template_callback (widget_class, cancel_clicked);
+  gtk_widget_class_bind_template_callback (widget_class, open_clicked);
+  gtk_widget_class_bind_template_callback (widget_class, find_in_software);
+}
+
+/* Ellipsize the location, keeping the suffix which is likely
+ * to have more relevant information, such as filename and extension.
+ */
+static char *
+shorten_location (const char *location)
+{
+  int len;
+
+  if (location == NULL)
+    return NULL;
+
+  len = g_utf8_strlen (location, -1);
+
+  if (len < LOCATION_MAX_LENGTH)
+    return g_strdup (location);
+
+  for (; len >= LOCATION_MAX_LENGTH; len--)
+    location = g_utf8_next_char (location);
+
+  return g_strconcat ("…", location, NULL);
+}
+
+static void
+ensure_default_in_initial_list (const char **choices,
+                                const char  *default_id)
+{
+  int i;
+  guint n_choices;
+
+  if (default_id == NULL)
+    return;
+
+  n_choices = g_strv_length ((char **)choices);
+  if (n_choices <= INITIAL_LIST_SIZE)
+    return;
+
+  for (i = 0; i < INITIAL_LIST_SIZE; i++)
+    {
+      if (strcmp (choices[i], default_id) == 0)
+        return;
+    }
+
+  for (i = INITIAL_LIST_SIZE; i < n_choices; i++)
+    {
+      if (strcmp (choices[i], default_id) == 0)
+        {
+          const char *tmp = choices[0];
+          choices[0] = choices[i];
+          choices[i] = tmp;
+          return;
+        }
+    }
+
+  g_warning ("default_id not found\n");
+}
+
+static void
+more_pressed (GtkGestureMultiPress *gesture,
+              int n_press,
+              double x,
+              double y,
+              AppChooserDialog *dialog)
+{
+  if (n_press != 1)
+    return;
+
+  if (gtk_list_box_get_row_at_y (GTK_LIST_BOX (dialog->list), y) == GTK_LIST_BOX_ROW (dialog->more_row))
+    show_more (dialog);
+}
+
+AppChooserDialog *
+app_chooser_dialog_new (const char **choices,
+                        const char *default_id,
+                        const char *content_type,
+                        const char *location)
+{
+  AppChooserDialog *dialog;
+  int n_choices;
+  int i;
+  g_autofree char *short_location = shorten_location (location);
+
+  dialog = g_object_new (app_chooser_dialog_get_type (), NULL);
+
+  dialog->content_type = g_strdup (content_type);
+
+  if (location)
+    {
+      g_autofree char *heading = NULL;
+
+      heading = g_strdup_printf (_("Choose an application to open the file “%s”."), short_location);
+      gtk_label_set_label (GTK_LABEL (dialog->heading), heading);
+    }
+  else
+    {
+      gtk_label_set_label (GTK_LABEL (dialog->heading), _("Choose an application."));
+    }
+
+  ensure_default_in_initial_list (choices, default_id);
+
+  dialog->choices = g_strdupv ((char **)choices);
+
+  n_choices = g_strv_length ((char **)choices);
+  if (n_choices == 0)
+    {
+      gtk_widget_show (dialog->empty_box);
+      gtk_stack_set_visible_child_name (GTK_STACK (dialog->stack), "empty");
+      gtk_widget_grab_default (dialog->find_software_button);
+      if (location)
+        {
+          g_autofree char *label = NULL;
+
+          label = g_strdup_printf (_("No apps installed that can open “%s”. You can find more applications in Software Manager"), short_location);
+          gtk_label_set_label (GTK_LABEL (dialog->empty_label), label);
+        }
+      else
+        {
+          gtk_label_set_label (GTK_LABEL (dialog->empty_label), _("No suitable app installed. You can find more applications in Software Manager."));
+        }
+    }
+  else
+    {
+      gtk_stack_set_visible_child_name (GTK_STACK (dialog->stack), "list");
+      gtk_widget_grab_default (dialog->open_button);
+      for (i = 0; i < MIN (n_choices, INITIAL_LIST_SIZE); i++)
+        {
+          g_autofree char *desktop_id = g_strconcat (choices[i], ".desktop", NULL);
+          g_autoptr(GAppInfo) info = G_APP_INFO (g_desktop_app_info_new (desktop_id));
+          GtkWidget *row;
+
+          row = GTK_WIDGET (app_chooser_row_new (info));
+          gtk_widget_set_visible (row, TRUE);
+          gtk_list_box_insert (GTK_LIST_BOX (dialog->list), row, -1);
+
+          if (default_id && strcmp (choices[i], default_id) == 0)
+            {
+              gtk_list_box_select_row (GTK_LIST_BOX (dialog->list), GTK_LIST_BOX_ROW (row));
+              gtk_widget_set_sensitive (dialog->open_button, TRUE);
+              dialog->selected_row = row;
+            }
+        }
+      if (n_choices > INITIAL_LIST_SIZE)
+        {
+          GtkWidget *row;
+          GtkWidget *image;
+          GtkGesture *gesture;
+
+          row = GTK_WIDGET (gtk_list_box_row_new ());
+
+          gesture = gtk_gesture_multi_press_new (dialog->list);
+          gtk_gesture_single_set_touch_only (GTK_GESTURE_SINGLE (gesture), FALSE);
+          gtk_event_controller_set_propagation_phase (GTK_EVENT_CONTROLLER (gesture), GTK_PHASE_BUBBLE);
+          gtk_gesture_single_set_button (GTK_GESTURE_SINGLE (gesture), GDK_BUTTON_PRIMARY);
+
+          g_signal_connect (gesture, "pressed", G_CALLBACK (more_pressed), dialog);
+
+          gtk_list_box_row_set_selectable (GTK_LIST_BOX_ROW (row), FALSE);
+          image = gtk_image_new_from_icon_name ("view-more-symbolic", GTK_ICON_SIZE_BUTTON);
+          g_object_set (image, "margin", 14, NULL);
+          gtk_container_add (GTK_CONTAINER (row), image);
+          gtk_widget_set_visible (row, TRUE);
+          gtk_widget_set_visible (image, TRUE);
+          gtk_list_box_insert (GTK_LIST_BOX (dialog->list), row, -1);
+          dialog->more_row = row;
+        }
+      
+    }
+
+  return dialog;
+}
+
+void
+app_chooser_dialog_update_choices (AppChooserDialog  *dialog,
+                                   const char       **choices)
+{
+  int i;
+  GPtrArray *new_choices;
+
+  new_choices = g_ptr_array_new ();
+  g_ptr_array_set_size (new_choices, g_strv_length (dialog->choices));
+  for (i = 0; dialog->choices[i]; i++)
+    new_choices->pdata[i] = dialog->choices[i];
+
+  for (i = 0; choices[i]; i++)
+    {
+      if (g_strv_contains ((const char * const *)dialog->choices, choices[i]))
+        continue;
+
+      g_ptr_array_add (new_choices, g_strdup (choices[i]));
+
+      if (!gtk_widget_get_visible (dialog->more_row))
+        {
+          g_autofree char *desktop_id = NULL;
+          g_autoptr(GAppInfo) info = NULL;
+          GtkWidget *row;
+
+          desktop_id = g_strconcat (choices[i], ".desktop", NULL);
+          info = G_APP_INFO (g_desktop_app_info_new (desktop_id));
+
+          row = GTK_WIDGET (app_chooser_row_new (info));
+          gtk_widget_set_visible (row, TRUE);
+          gtk_list_box_insert (GTK_LIST_BOX (dialog->list), row, -1);
+       }
+    }
+
+  g_ptr_array_add (new_choices, NULL);
+
+  g_free (dialog->choices);
+  dialog->choices = (char **) g_ptr_array_free (new_choices, FALSE);
+}

--- a/src/appchooserdialog.c
+++ b/src/appchooserdialog.c
@@ -140,6 +140,9 @@ show_more (AppChooserDialog *dialog)
       g_autoptr(GAppInfo) info = G_APP_INFO (g_desktop_app_info_new (desktop_id));
       GtkWidget *row;
 
+      if (info == NULL)
+        continue;
+
       row = GTK_WIDGET (app_chooser_row_new (info));
       gtk_widget_set_visible (row, TRUE);
       gtk_list_box_insert (GTK_LIST_BOX (dialog->list), row, -1);
@@ -416,6 +419,9 @@ app_chooser_dialog_new (const char **choices,
           g_autoptr(GAppInfo) info = G_APP_INFO (g_desktop_app_info_new (desktop_id));
           GtkWidget *row;
 
+          if (info == NULL)
+            continue;
+
           row = GTK_WIDGET (app_chooser_row_new (info));
           gtk_widget_set_visible (row, TRUE);
           gtk_list_box_insert (GTK_LIST_BOX (dialog->list), row, -1);
@@ -481,6 +487,9 @@ app_chooser_dialog_update_choices (AppChooserDialog  *dialog,
           g_autofree char *desktop_id = NULL;
           g_autoptr(GAppInfo) info = NULL;
           GtkWidget *row;
+
+          if (info == NULL)
+            continue;
 
           desktop_id = g_strconcat (choices[i], ".desktop", NULL);
           info = G_APP_INFO (g_desktop_app_info_new (desktop_id));

--- a/src/appchooserdialog.h
+++ b/src/appchooserdialog.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2016 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Matthias Clasen <mclasen@redhat.com>
+ */
+
+#pragma once
+
+#include <gtk/gtk.h>
+
+#define APP_TYPE_CHOOSER_DIALOG (app_chooser_dialog_get_type ())
+#define APP_CHOOSER_DIALOG(object) (G_TYPE_CHECK_INSTANCE_CAST (object, APP_TYPE_CHOOSER_DIALOG, AppChooserDialog))
+
+typedef struct _AppChooserDialog AppChooserDialog;
+typedef struct _AppChooserDialogClass AppChooserDialogClass;
+
+GType              app_chooser_dialog_get_type (void) G_GNUC_CONST;
+
+AppChooserDialog * app_chooser_dialog_new (const char **app_ids,
+                                           const char  *default_id,
+                                           const char  *content_type,
+                                           const char  *filename);
+
+void      app_chooser_dialog_update_choices (AppChooserDialog *dialog,
+                                             const char       **app_ids);
+
+GAppInfo *app_chooser_dialog_get_info (AppChooserDialog *dialog);

--- a/src/appchooserdialog.ui
+++ b/src/appchooserdialog.ui
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface domain="xdg-desktop-portal-gtk">
+  <!-- interface-requires gtk+ 3.22 -->
+  <template class="AppChooserDialog" parent="GtkWindow">
+    <property name="type-hint">dialog</property>
+    <property name="resizable">0</property>
+    <child type="titlebar">
+      <object class="GtkHeaderBar" id="titlebar">
+        <property name="visible">1</property>
+        <property name="title" translatable="yes">Open With…</property>
+        <child>
+          <object class="GtkButton" id="cancel_button">
+            <property name="visible">1</property>
+            <property name="label" translatable="yes">_Cancel</property>
+            <property name="use-underline">1</property>
+            <signal name="clicked" handler="cancel_clicked"/>
+          </object>
+        </child>
+        <child>
+          <object class="GtkButton" id="open_button">
+            <property name="visible">1</property>
+            <property name="sensitive">0</property>
+            <property name="label" translatable="yes">_Open</property>
+            <property name="use-underline">1</property>
+            <property name="can-default">1</property>
+            <signal name="clicked" handler="open_clicked"/>
+            <style>
+              <class name="suggested-action"/>
+            </style>
+          </object>
+          <packing>
+            <property name="pack-type">end</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">1</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkStack" id="stack">
+            <property name="visible">1</property>
+            <child>
+              <object class="GtkScrolledWindow" id="scrolled_window">
+                <property name="visible">1</property>
+                <property name="expand">1</property>
+                <property name="hscrollbar-policy">never</property>
+                <property name="vscrollbar-policy">never</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="orientation">vertical</property>
+                    <property name="halign">fill</property>
+                    <property name="valign">fill</property>
+                    <child>
+                      <object class="GtkLabel" id="heading">
+                        <property name="visible">1</property>
+                        <property name="halign">start</property>
+                        <property name="xalign">0</property>
+                        <property name="margin">20</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkListBox" id="list">
+                        <style>
+                          <class name="frame"/>
+                          <class name="view"/>
+                        </style>
+                        <signal name="row-activated" handler="row_activated"/>
+                        <signal name="row-selected" handler="row_selected"/>
+                        <property name="selection-mode">single</property>
+                        <property name="activate-on-single-click">0</property>
+                        <property name="visible">1</property>
+                        <property name="margin-left">20</property>
+                        <property name="margin-right">20</property>
+                        <property name="margin-bottom">20</property>
+                        <property name="halign">fill</property>
+                        <property name="valign">fill</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="name">list</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="empty_box">
+                <property name="visible">0</property>
+                <property name="orientation">vertical</property>
+                <style>
+                  <class name="view"/>
+                </style>
+                <child type="center">
+                  <object class="GtkBox">
+                    <property name="visible">1</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <object class="GtkImage" id="empty_image">
+                        <property name="margin-top">40</property>
+                        <property name="visible">1</property>
+                        <property name="icon-name">mintinstall</property>
+                        <property name="pixel-size">128</property>
+                        <style>
+                          <class name="dim-label"/>
+                        </style>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="empty_heading">
+                        <property name="margin-top">40</property>
+                        <property name="visible">1</property>
+                        <property name="label" translatable="yes">No Apps available</property>
+                        <attributes>
+                          <attribute name="weight" value="600"/>
+                          <attribute name="scale" value="1.44"/>
+                        </attributes>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="empty_label">
+                        <property name="margin-top">20</property>
+                        <property name="margin-start">40</property>
+                        <property name="margin-end">40</property>
+                        <property name="visible">1</property>
+                        <property name="wrap">1</property>
+                        <property name="max-width-chars">45</property>
+                        <property name="wrap-mode">word</property>
+                        <property name="label">No apps installed that are able to open file.extension. You can find more applications in Software Manager.</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="find_software_button">
+                        <property name="visible">1</property>
+                        <property name="halign">center</property>
+                        <property name="margin">30</property>
+                        <property name="can-default">1</property>
+                        <style>
+                          <class name="suggested-action"/>
+                        </style>
+                        <signal name="clicked" handler="find_in_software"/>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">1</property>
+                            <property name="spacing">6</property>
+                            <property name="halign">center</property>
+                            <property name="valign">center</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">1</property>
+                                <property name="icon-name">mintinstall</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">1</property>
+                                <property name="label" translatable="yes">_Find More in Software Manager</property>
+                                <property name="use-underline">1</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="name">empty</property>
+              </packing>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/src/appchooserdialog.ui
+++ b/src/appchooserdialog.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<interface domain="xdg-desktop-portal-gtk">
+<interface domain="xdg-desktop-portal-xapp">
   <!-- interface-requires gtk+ 3.22 -->
   <template class="AppChooserDialog" parent="GtkWindow">
     <property name="type-hint">dialog</property>

--- a/src/appchooserrow.c
+++ b/src/appchooserrow.c
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2016 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Matthias Clasen <mclasen@redhat.com>
+ */
+
+#include "config.h"
+#include "appchooserrow.h"
+
+struct _AppChooserRow {
+  GtkListBoxRow parent;
+
+  GAppInfo *info;
+  gboolean selected;
+
+  GtkWidget *icon;
+  GtkWidget *name;
+  GtkWidget *check;
+};
+
+struct _AppChooserRowClass {
+  GtkListBoxRowClass parent_class;
+};
+
+G_DEFINE_TYPE (AppChooserRow, app_chooser_row, GTK_TYPE_LIST_BOX_ROW)
+
+static void
+app_chooser_row_init (AppChooserRow *row)
+{
+  gtk_widget_init_template (GTK_WIDGET (row));
+}
+
+static void
+app_chooser_row_finalize (GObject *object)
+{
+  AppChooserRow *row = APP_CHOOSER_ROW (object);
+
+  g_clear_object (&row->info);
+
+  G_OBJECT_CLASS (app_chooser_row_parent_class)->finalize (object);
+}
+
+static void
+app_chooser_row_class_init (AppChooserRowClass *class)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (class);
+  GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (class);
+
+  object_class->finalize = app_chooser_row_finalize;
+
+  gtk_widget_class_set_template_from_resource (widget_class, "/org/freedesktop/portal/desktop/xapp/appchooserrow.ui");
+  gtk_widget_class_bind_template_child (widget_class, AppChooserRow, icon);
+  gtk_widget_class_bind_template_child (widget_class, AppChooserRow, name);
+  gtk_widget_class_bind_template_child (widget_class, AppChooserRow, check);
+}
+
+AppChooserRow *
+app_chooser_row_new (GAppInfo *info)
+{
+  AppChooserRow *row;
+  GIcon *icon;
+
+  row = g_object_new (app_chooser_row_get_type (), NULL);
+
+  g_set_object (&row->info, info);
+
+  icon = g_app_info_get_icon (info);
+  if (!icon)
+    icon = g_themed_icon_new ("application-x-executable");
+
+  gtk_image_set_from_gicon (GTK_IMAGE (row->icon), icon, GTK_ICON_SIZE_DIALOG);
+  gtk_image_set_pixel_size (GTK_IMAGE (row->icon), 32);
+  gtk_label_set_label (GTK_LABEL (row->name), g_app_info_get_name (info));
+
+  return row;
+}
+
+GAppInfo *
+app_chooser_row_get_info (AppChooserRow *row)
+{
+  return row->info;
+}
+
+void
+app_chooser_row_set_selected (AppChooserRow *row,
+                              gboolean       selected)
+{
+  gtk_widget_set_opacity (row->check, selected ? 1.0 : 0.0);
+}

--- a/src/appchooserrow.h
+++ b/src/appchooserrow.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2016 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Matthias Clasen <mclasen@redhat.com>
+ */
+
+#pragma once
+
+#include <gtk/gtk.h>
+
+#define APP_TYPE_CHOOSER_ROW (app_chooser_row_get_type ())
+#define APP_CHOOSER_ROW(object) (G_TYPE_CHECK_INSTANCE_CAST (object, APP_TYPE_CHOOSER_ROW, AppChooserRow))
+
+typedef struct _AppChooserRow AppChooserRow;
+typedef struct _AppChooserRowClass AppChooserRowClass;
+
+GType app_chooser_row_get_type (void);
+AppChooserRow *app_chooser_row_new (GAppInfo *info);
+GAppInfo *app_chooser_row_get_info (AppChooserRow *row);
+void app_chooser_row_set_selected (AppChooserRow *row,
+                                   gboolean       selected);

--- a/src/appchooserrow.ui
+++ b/src/appchooserrow.ui
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface domain="xdg-desktop-portal-gtk">
+  <!-- interface-requires gtk+ 3.22 -->
+  <template class="AppChooserRow" parent="GtkListBoxRow">
+    <property name="visible">1</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">1</property>
+        <property name="orientation">horizontal</property>
+        <property name="spacing">10</property>
+        <property name="halign">fill</property>
+        <child>
+          <object class="GtkImage" id="icon">
+            <property name="visible">1</property>
+            <property name="margin">10</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="name">
+            <property name="visible">1</property>
+            <property name="xalign">0</property>
+            <property name="width-chars">30</property>
+            <property name="max-width-chars">30</property>
+            <property name="hexpand">1</property>
+            <property name="ellipsize">end</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkImage" id="check">
+            <property name="visible">1</property>
+            <property name="margin">10</property>
+            <property name="opacity">0</property>
+            <property name="icon-name">object-select-symbolic</property>
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/src/appchooserrow.ui
+++ b/src/appchooserrow.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<interface domain="xdg-desktop-portal-gtk">
+<interface domain="xdg-desktop-portal-xapp">
   <!-- interface-requires gtk+ 3.22 -->
   <template class="AppChooserRow" parent="GtkListBoxRow">
     <property name="visible">1</property>

--- a/src/externalwindow-wayland.c
+++ b/src/externalwindow-wayland.c
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2016 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Jonas Ådahl <jadahl@redhat.com>
+ */
+
+#include "config.h"
+
+#include <gdk/gdk.h>
+#include <gdk/gdkwayland.h>
+
+#include "externalwindow-wayland.h"
+
+static GdkDisplay *wayland_display;
+
+struct _ExternalWindowWayland
+{
+  ExternalWindow parent;
+
+  char *handle_str;
+};
+
+struct _ExternalWindowWaylandClass
+{
+  ExternalWindowClass parent_class;
+};
+
+G_DEFINE_TYPE (ExternalWindowWayland, external_window_wayland,
+               EXTERNAL_TYPE_WINDOW)
+
+static GdkDisplay *
+get_wayland_display (void)
+{
+  if (wayland_display)
+    return wayland_display;
+
+  gdk_set_allowed_backends ("wayland");
+  wayland_display = gdk_display_open (NULL);
+  gdk_set_allowed_backends (NULL);
+  if (!wayland_display)
+    g_warning ("Failed to open Wayland display");
+
+  return wayland_display;
+}
+
+ExternalWindowWayland *
+external_window_wayland_new (const char *handle_str)
+{
+  ExternalWindowWayland *external_window_wayland;
+  GdkDisplay *display;
+
+  display = get_wayland_display ();
+  if (!display)
+    {
+      g_warning ("No Wayland display connection, ignoring Wayland parent");
+      return NULL;
+    }
+
+  external_window_wayland = g_object_new (EXTERNAL_TYPE_WINDOW_WAYLAND,
+                                          "display", display,
+                                          NULL);
+  external_window_wayland->handle_str = g_strdup (handle_str);
+
+  return external_window_wayland;
+}
+
+static void
+external_window_wayland_set_parent_of (ExternalWindow *external_window,
+                                       GdkWindow      *child_window)
+{
+  ExternalWindowWayland *external_window_wayland =
+    EXTERNAL_WINDOW_WAYLAND (external_window);
+  char *handle_str = external_window_wayland->handle_str;
+
+  if (!gdk_wayland_window_set_transient_for_exported (child_window, handle_str))
+    g_warning ("Failed to set portal window transient for external parent");
+}
+
+static void
+external_window_wayland_dispose (GObject *object)
+{
+  ExternalWindowWayland *external_window_wayland =
+    EXTERNAL_WINDOW_WAYLAND (object);
+
+  g_free (external_window_wayland->handle_str);
+
+  G_OBJECT_CLASS (external_window_wayland_parent_class)->dispose (object);
+}
+
+static void
+external_window_wayland_init (ExternalWindowWayland *external_window_wayland)
+{
+}
+
+static void
+external_window_wayland_class_init (ExternalWindowWaylandClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ExternalWindowClass *external_window_class = EXTERNAL_WINDOW_CLASS (klass);
+
+  object_class->dispose = external_window_wayland_dispose;
+
+  external_window_class->set_parent_of = external_window_wayland_set_parent_of;
+}

--- a/src/externalwindow-wayland.h
+++ b/src/externalwindow-wayland.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2016 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Jonas Ådahl <jadahl@redhat.com>
+ */
+
+#pragma once
+
+#include <glib-object.h>
+
+#include "externalwindow.h"
+
+#define EXTERNAL_TYPE_WINDOW_WAYLAND (external_window_wayland_get_type ())
+#define EXTERNAL_WINDOW_WAYLAND(object) (G_TYPE_CHECK_INSTANCE_CAST (object, EXTERNAL_TYPE_WINDOW_WAYLAND, ExternalWindowWayland))
+
+typedef struct _ExternalWindowWayland ExternalWindowWayland;
+typedef struct _ExternalWindowWaylandClass ExternalWindowWaylandClass;
+
+GType external_window_wayland_get_type (void);
+ExternalWindowWayland *external_window_wayland_new (const char *handle_str);

--- a/src/externalwindow-x11.c
+++ b/src/externalwindow-x11.c
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2016 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Jonas Ådahl <jadahl@redhat.com>
+ */
+
+#include "config.h"
+
+#include <errno.h>
+#include <gdk/gdkx.h>
+#include <gdk/gdk.h>
+#include <stdlib.h>
+
+#include "externalwindow-x11.h"
+
+
+static GdkDisplay *x11_display;
+
+struct _ExternalWindowX11
+{
+  ExternalWindow parent;
+
+  GdkWindow *foreign_gdk_window;
+};
+
+struct _ExternalWindowX11Class
+{
+  ExternalWindowClass parent_class;
+};
+
+G_DEFINE_TYPE (ExternalWindowX11, external_window_x11,
+               EXTERNAL_TYPE_WINDOW)
+
+static GdkDisplay *
+get_x11_display (void)
+{
+  if (x11_display)
+    return x11_display;
+
+  gdk_set_allowed_backends ("x11");
+  x11_display = gdk_display_open (NULL);
+  gdk_set_allowed_backends (NULL);
+  if (!x11_display)
+    g_warning ("Failed to open X11 display");
+
+  return x11_display;
+}
+
+ExternalWindowX11 *
+external_window_x11_new (const char *handle_str)
+{
+  ExternalWindowX11 *external_window_x11;
+  GdkDisplay *display;
+  int xid;
+  GdkWindow *foreign_gdk_window;
+
+  display = get_x11_display ();
+  if (!display)
+    {
+      g_warning ("No X display connection, ignoring X11 parent");
+      return NULL;
+    }
+
+  errno = 0;
+  xid = strtol (handle_str, NULL, 16);
+  if (errno != 0)
+    {
+      g_warning ("Failed to reference external X11 window, invalid XID %s", handle_str);
+      return NULL;
+    }
+
+  foreign_gdk_window = gdk_x11_window_foreign_new_for_display (display, xid);
+  if (!foreign_gdk_window)
+    {
+      g_warning ("Failed to create foreign window for XID %d", xid);
+      return NULL;
+    }
+
+  external_window_x11 = g_object_new (EXTERNAL_TYPE_WINDOW_X11,
+                                      "display", display,
+                                      NULL);
+  external_window_x11->foreign_gdk_window = foreign_gdk_window;
+
+  return external_window_x11;
+}
+
+static void
+external_window_x11_set_parent_of (ExternalWindow *external_window,
+                                   GdkWindow      *child_window)
+{
+  ExternalWindowX11 *external_window_x11 =
+    EXTERNAL_WINDOW_X11 (external_window);
+
+  gdk_window_set_transient_for (child_window,
+                                external_window_x11->foreign_gdk_window);
+}
+
+static void
+external_window_x11_dispose (GObject *object)
+{
+  ExternalWindowX11 *external_window_x11 = EXTERNAL_WINDOW_X11 (object);
+
+  g_clear_object (&external_window_x11->foreign_gdk_window);
+
+  G_OBJECT_CLASS (external_window_x11_parent_class)->dispose (object);
+}
+
+static void
+external_window_x11_init (ExternalWindowX11 *external_window_x11)
+{
+}
+
+static void
+external_window_x11_class_init (ExternalWindowX11Class *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ExternalWindowClass *external_window_class = EXTERNAL_WINDOW_CLASS (klass);
+
+  object_class->dispose = external_window_x11_dispose;
+
+  external_window_class->set_parent_of = external_window_x11_set_parent_of;
+}

--- a/src/externalwindow-x11.h
+++ b/src/externalwindow-x11.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2016 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Jonas Ådahl <jadahl@redhat.com>
+ */
+
+#pragma once
+
+#include <glib-object.h>
+
+#include "externalwindow.h"
+
+
+#define EXTERNAL_TYPE_WINDOW_X11 (external_window_x11_get_type ())
+#define EXTERNAL_WINDOW_X11(object) (G_TYPE_CHECK_INSTANCE_CAST (object, EXTERNAL_TYPE_WINDOW_X11, ExternalWindowX11))
+
+typedef struct _ExternalWindowX11 ExternalWindowX11;
+typedef struct _ExternalWindowX11Class ExternalWindowX11Class;
+
+GType external_window_get_type (void);
+ExternalWindowX11 *external_window_x11_new (const char *handle_str);

--- a/src/externalwindow.c
+++ b/src/externalwindow.c
@@ -1,0 +1,163 @@
+/*
+ * Copyright © 2016 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Jonas Ådahl <jadahl@redhat.com>
+ */
+
+#include "config.h"
+
+#include <string.h>
+
+#include "externalwindow.h"
+#ifdef HAVE_GTK_X11
+#include "externalwindow-x11.h"
+#endif
+#ifdef HAVE_GTK_WAYLAND
+#include "externalwindow-wayland.h"
+#endif
+
+enum
+{
+  PROP_0,
+
+  PROP_DISPLAY,
+};
+
+typedef struct _ExternalWindowPrivate
+{
+  GdkDisplay *display;
+} ExternalWindowPrivate;
+
+G_DEFINE_TYPE_WITH_PRIVATE (ExternalWindow, external_window, G_TYPE_OBJECT)
+
+ExternalWindow *
+create_external_window_from_handle (const char *handle_str)
+{
+#ifdef HAVE_GTK_X11
+    {
+      const char x11_prefix[] = "x11:";
+      if (g_str_has_prefix (handle_str, x11_prefix))
+        {
+          ExternalWindowX11 *external_window_x11;
+          const char *x11_handle_str = handle_str + strlen (x11_prefix);
+
+          external_window_x11 = external_window_x11_new (x11_handle_str);
+          return EXTERNAL_WINDOW (external_window_x11);
+        }
+    }
+#endif
+#ifdef HAVE_GTK_WAYLAND
+    {
+      const char wayland_prefix[] = "wayland:";
+      if (g_str_has_prefix (handle_str, wayland_prefix))
+        {
+          ExternalWindowWayland *external_window_wayland;
+          const char *wayland_handle_str = handle_str + strlen (wayland_prefix);
+
+          external_window_wayland =
+            external_window_wayland_new (wayland_handle_str);
+          return EXTERNAL_WINDOW (external_window_wayland);
+        }
+    }
+#endif
+
+  g_warning ("Unhandled parent window type %s\n", handle_str);
+  return NULL;
+}
+
+void
+external_window_set_parent_of (ExternalWindow *external_window,
+                               GdkWindow      *child_window)
+{
+  EXTERNAL_WINDOW_GET_CLASS (external_window)->set_parent_of (external_window,
+                                                              child_window);
+}
+
+GdkDisplay *
+external_window_get_display (ExternalWindow *external_window)
+{
+  ExternalWindowPrivate *priv =
+    external_window_get_instance_private (external_window);
+
+  return priv->display;
+}
+
+static void
+external_window_set_property (GObject      *object,
+                              guint         prop_id,
+                              const GValue *value,
+                              GParamSpec   *pspec)
+{
+  ExternalWindow *external_window = EXTERNAL_WINDOW (object);
+  ExternalWindowPrivate *priv =
+    external_window_get_instance_private (external_window);
+
+  switch (prop_id)
+    {
+    case PROP_DISPLAY:
+      g_set_object (&priv->display, g_value_get_object (value));
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+external_window_get_property (GObject    *object,
+                              guint       prop_id,
+                              GValue     *value,
+                              GParamSpec *pspec)
+{
+  ExternalWindow *external_window = EXTERNAL_WINDOW (object);
+  ExternalWindowPrivate *priv =
+    external_window_get_instance_private (external_window);
+
+  switch (prop_id)
+    {
+    case PROP_DISPLAY:
+      g_value_set_object (value, priv->display);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+external_window_init (ExternalWindow *external_window)
+{
+}
+
+static void
+external_window_class_init (ExternalWindowClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->get_property = external_window_get_property;
+  object_class->set_property = external_window_set_property;
+
+  g_object_class_install_property (object_class,
+                                   PROP_DISPLAY,
+                                   g_param_spec_object ("display",
+                                                        "GdkDisplay",
+                                                        "The GdkDisplay instance",
+                                                        GDK_TYPE_DISPLAY,
+                                                        G_PARAM_READWRITE |
+                                                        G_PARAM_CONSTRUCT_ONLY |
+                                                        G_PARAM_STATIC_STRINGS));
+}

--- a/src/externalwindow.h
+++ b/src/externalwindow.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2016 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Jonas Ådahl <jadahl@redhat.com>
+ */
+
+#pragma once
+
+#include <glib-object.h>
+#include <gtk/gtk.h>
+
+
+#define EXTERNAL_TYPE_WINDOW (external_window_get_type ())
+#define EXTERNAL_WINDOW(object) (G_TYPE_CHECK_INSTANCE_CAST (object, EXTERNAL_TYPE_WINDOW, ExternalWindow))
+#define EXTERNAL_WINDOW_CLASS(klass) (G_TYPE_CHECK_CLASS_CAST (klass, EXTERNAL_TYPE_WINDOW, ExternalWindowClass))
+#define EXTERNAL_WINDOW_GET_CLASS(klass) (G_TYPE_INSTANCE_GET_CLASS (klass, EXTERNAL_TYPE_WINDOW, ExternalWindowClass))
+
+typedef struct _ExternalWindow ExternalWindow;
+typedef struct _ExternalWindowClass ExternalWindowClass;
+
+struct _ExternalWindow
+{
+  GObject parent_instance;
+};
+
+struct _ExternalWindowClass
+{
+  GObjectClass parent_class;
+
+  void (*set_parent_of) (ExternalWindow *external_window,
+                         GdkWindow      *child_window);
+};
+
+GType external_window_get_type (void);
+ExternalWindow *create_external_window_from_handle (const char *handle_str);
+
+void external_window_set_parent_of (ExternalWindow *external_window,
+                                    GdkWindow      *child_window);
+
+GdkDisplay *external_window_get_display (ExternalWindow *external_window);

--- a/src/meson.build
+++ b/src/meson.build
@@ -11,6 +11,7 @@ desktop_portal_interfaces_dir = xdg_desktop_portal_dep.get_variable(
 )
 
 desktop_portal_dbus_interfaces = [
+  desktop_portal_interfaces_dir / 'org.freedesktop.impl.portal.AppChooser.xml',
   desktop_portal_interfaces_dir / 'org.freedesktop.impl.portal.Background.xml',
   desktop_portal_interfaces_dir / 'org.freedesktop.impl.portal.Inhibit.xml',
   desktop_portal_interfaces_dir / 'org.freedesktop.impl.portal.Lockdown.xml',
@@ -30,6 +31,13 @@ built_sources = gnome.gdbus_codegen(
   sources: desktop_portal_dbus_interfaces,
   interface_prefix: 'org.freedesktop.impl.portal.',
   namespace: 'XdpImpl',
+)
+
+# GResources
+built_sources += gnome.compile_resources(
+  'xdg-desktop-portal-xapp-resources',
+  'xdg-desktop-portal-xapp.gresource.xml',
+  c_name: '_xdg_desktop',
 )
 
 desktop_dbus_interfaces = files(
@@ -66,7 +74,13 @@ deps = [
 ]
 
 sources = built_sources + files(
+  'appchooser.c',
+  'appchooserdialog.c',
+  'appchooserrow.c',
   'background.c',
+  'externalwindow.c',
+  'externalwindow-wayland.c',
+  'externalwindow-x11.c',
   'inhibit.c',
   'lockdown.c',
   'request.c',

--- a/src/meson.build
+++ b/src/meson.build
@@ -79,8 +79,6 @@ sources = built_sources + files(
   'appchooserrow.c',
   'background.c',
   'externalwindow.c',
-  'externalwindow-wayland.c',
-  'externalwindow-x11.c',
   'inhibit.c',
   'lockdown.c',
   'request.c',
@@ -91,6 +89,23 @@ sources = built_sources + files(
   'wallpaper.c',
   'xdg-desktop-portal-xapp.c',
 )
+
+common_flags = []
+
+gtk_x11_dep = dependency('gdk-x11-3.0', required: false)
+if gtk_x11_dep.found()
+  sources += files('externalwindow-x11.c')
+  deps += [dependency('x11')]
+  common_flags += ['-DHAVE_GTK_X11']
+endif
+
+gtk_wayland_dep = dependency('gdk-wayland-3.0', required: false)
+if gtk_wayland_dep.found()
+  sources += files('externalwindow-wayland.c')
+  common_flags += ['-DHAVE_GTK_WAYLAND']
+endif
+
+add_project_arguments(common_flags, language: 'c')
 
 executable(
   'xdg-desktop-portal-xapp',

--- a/src/xdg-desktop-portal-xapp.c
+++ b/src/xdg-desktop-portal-xapp.c
@@ -44,6 +44,7 @@
 #include "xdg-desktop-portal-dbus.h"
 
 #include "utils.h"
+#include "appchooser.h"
 #include "background.h"
 #include "inhibit.h"
 #include "lockdown.h"
@@ -118,6 +119,12 @@ on_bus_acquired (GDBusConnection *connection,
   {
     return;
   }
+
+  if (!app_chooser_init(connection, &error))
+    {
+      g_warning ("error: %s\n", error->message);
+      g_clear_error (&error);
+    }
 
   if ((CINNAMON_MODE || XFCE_MODE) && !screenshot_init (connection, &error))
     {

--- a/src/xdg-desktop-portal-xapp.gresource.xml
+++ b/src/xdg-desktop-portal-xapp.gresource.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<gresources>
+  <gresource prefix='/org/freedesktop/portal/desktop/xapp'>
+    <file>appchooserdialog.ui</file>
+    <file>appchooserrow.ui</file>
+  </gresource>
+</gresources>
+


### PR DESCRIPTION
This portal is used when the system has several programs capable of opening the selected file type. If such programs are missing, they are offered for installation through the system application manager (in this case, mintinstall). Without this PR, a similar portal for GNOME, linked to gnome-software, is used. Tested with Dolphin installed from Flatpak.

Before: 
<img width="1920" height="944" alt="Снимок экрана_20260112_003613" src="https://github.com/user-attachments/assets/2311e4f4-b91b-47b1-8a6b-425fbb2cfee9" />

After: 
<img width="1920" height="939" alt="Снимок экрана_20260112_003833" src="https://github.com/user-attachments/assets/ba18f88d-df60-4823-8862-4321f60caf97" />
<img width="1920" height="937" alt="Снимок экрана_20260112_003851" src="https://github.com/user-attachments/assets/8a7805bb-5819-4cbc-99bf-31f881dbb36d" />
